### PR TITLE
Synopsys: Automated PR: Update org.apache.logging.log4j:log4j-core:2.14.1 to 2.24.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.14.1</version>
+      <version>2.24.0</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
## Vulnerabilities associated with org.apache.logging.log4j:log4j-core:2.14.1
[BDSA-2021-3731](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-3731) *(CRITICAL)*: Apache Log4j, as used in many popular services, is vulnerable to improperly allowing lightweight directory access protocol (LDAP) access via Java naming and directory interface (JNDI). A remote attacker able to supply the end application with specially crafted input that is then processed by the Log4j subcomponent could cause the execution of arbitrary Java code.

**Note** 

- log4j-api packages by themselves do not contain the vulnerable functionality and are therefore unaffected. log4j-core packages and the upstream overarching source repository are affected.

- A previously suggested mitigation of setting environment variable `LOG4J_FORMAT_MSG_NO_LOOKUPS=true` is not recommended. This mitigation has been proven inadequate against this vulnerability. 

- This vulnerability is partially fixed in [**2.15.0-rc2**](https://github.com/apache/logging-log4j2/releases/tag/log4j-2.15.0-rc2) by [this](https://github.com/apache/logging-log4j2/commit/001aaada7dab82c3c09cde5f8e14245dc9d8b454) commit and [this](https://github.com/apache/logging-log4j2/commit/bac0d8a35c7e354a0d3f706569116dff6c6bd658) commit. These fixes were deemed incomplete. See BDSA-2021-3779 (CVE-2021-45046) for more details.

This vulnerability is listed as exploitable by the Cybersecurity & Infrastructure Security Agency in their [Known Exploited Vulnerabilities Catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog).

[Click Here To See More Details On Server](https://poc357.blackduck.synopsys.com/api/projects/cfb6eae9-a8f3-42d9-896a-bd72b5fc707b/versions/963e7d14-73d3-4858-8e2d-4799a43666a7/vulnerability-bom?selectedItem=b14c1975-c1df-4a15-b4df-beb702cb3fb1)